### PR TITLE
Fix 0 xor 0

### DIFF
--- a/src/asm/xor.asm
+++ b/src/asm/xor.asm
@@ -9,6 +9,6 @@ _XorData:				; Credits to Runer112
 	ex	de, hl
 	add	hl, bc
 	sbc	a, c
-	adc	a, a
+	add	a, c
 	sbc	hl, hl
 	inc	hl


### PR DESCRIPTION
IIRC, the idea behind this approach was to make A zero if the result should be true and nonzero if the result should be false. This should be the case after `sbc a,c` on line 11. Then, adding -1 would convert zero to no carry and nonzero to carry, allowing the `sbc hl,hl \ inc hl` to convert to true (1) and false (0).